### PR TITLE
🚨 URGENT: Fix pnpm version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     
     - uses: pnpm/action-setup@v2
       with:
-        version: 8
+        version: 9
     
     - uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
## 🚨 Critical Fix

Fixes the Release workflow that was failing due to pnpm version mismatch.

## Problem
The Release workflow was using pnpm version 8, but the project now requires version 9 (as updated in the CI workflow).

## Solution
- Updated pnpm version from 8 to 9 in `.github/workflows/release.yml`

## Impact
This ensures the Release workflow can successfully:
- Install dependencies with `--frozen-lockfile`
- Build and publish packages to npm
- Prevent future release failures

**This is a critical fix that needs to be merged ASAP to ensure future releases work correctly.**