### PR TITLE
fix: remove npm publish from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,3 @@ jobs:
     
     - name: Build package
       run: pnpm build
-    
-    - name: Publish to npm
-      run: pnpm publish --no-git-checks --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Removes the automatic npm publish step from the Release workflow.

## Reason
We prefer to publish to npm manually for better control over the release process.

## Changes
- Removed `Publish to npm` step from `.github/workflows/release.yml`
- Workflow now only runs tests and builds the package when a tag is pushed
- Publishing to npm will be done manually as needed

This prevents authentication errors and gives us more control over when packages are published.