### PR TITLE
Optimize duplicate breakpoint detection and fix useEffect dependencies

### DIFF
--- a/src/BreakpointContext.tsx
+++ b/src/BreakpointContext.tsx
@@ -82,9 +82,18 @@ export const BreakpointProvider: React.FC<BreakpointProviderProps> = ({
 
   /** Check for duplicate breakpoint values */
   useEffect(() => {
-    const duplicates = sortedBreakpoints.filter(
-      ([, value], index) => sortedBreakpoints.findIndex(([, v]) => v === value) !== index
-    );
+    const seenValues = new Set<number>();
+    const duplicates: Array<[Breakpoint, number]> = [];
+
+    for (const entry of sortedBreakpoints) {
+      const [, value] = entry;
+      if (seenValues.has(value)) {
+        duplicates.push(entry);
+      } else {
+        seenValues.add(value);
+      }
+    }
+
     if (duplicates.length > 0) {
       if (shouldLog) {
         console.error(
@@ -92,7 +101,7 @@ export const BreakpointProvider: React.FC<BreakpointProviderProps> = ({
         );
       }
     }
-  }, [sortedBreakpoints]);
+  }, [sortedBreakpoints, shouldLog]);
 
   // Determine the current breakpoint based on the measured width. 📏
   const currentBreakpoint = useMemo(() => {


### PR DESCRIPTION
## Summary
- Optimize duplicate breakpoint detection from O(n²) to O(n) complexity
- Fix missing useEffect dependency to prevent stale closures
- Maintain existing functionality with improved performance

## Changes Made

### 🚀 Performance Optimization
**Before:** Used `filter` with `findIndex` causing O(n²) complexity
```typescript
const duplicates = sortedBreakpoints.filter(
  ([, value], index) => sortedBreakpoints.findIndex(([, v]) => v === value) !== index
);
```

**After:** Use Set-based approach for O(n) complexity
```typescript
const seenValues = new Set<number>();
const duplicates: Array<[Breakpoint, number]> = [];

for (const entry of sortedBreakpoints) {
  const [, value] = entry;
  if (seenValues.has(value)) {
    duplicates.push(entry);
  } else {
    seenValues.add(value);
  }
}
```

### 🔧 Bug Fix
**Before:** Missing dependency in useEffect
```typescript
}, [sortedBreakpoints]);
```

**After:** Complete dependency array
```typescript
}, [sortedBreakpoints, shouldLog]);
```

## Benefits
- ✅ **Performance:** Significantly better performance with larger breakpoint arrays
- ✅ **Correctness:** Prevents stale closure issues when `shouldLog` changes
- ✅ **Maintainability:** Cleaner, more explicit code
- ✅ **Testing:** All existing tests continue to pass

## Quality Checks
- ✅ All tests pass (5/5)
- ✅ ESLint validation passed
- ✅ TypeScript compilation successful
- ✅ Pre-commit hooks passed (lint, typecheck, build, test)

## Test plan
- [x] Existing functionality verified through test suite
- [x] Performance improvement confirmed (O(n) vs O(n²))
- [x] No regressions in duplicate detection logic
- [x] useEffect dependency fix prevents potential closure issues

Fixes #4